### PR TITLE
Fix buggy drcov parsers

### DIFF
--- a/plugin/lighthouse/parsers/drcov.py
+++ b/plugin/lighthouse/parsers/drcov.py
@@ -407,7 +407,7 @@ class DrcovModule(object):
         self.base          = int(data[2], 16)
         self.end           = int(data[3], 16)
         self.entry         = int(data[4], 16)
-        if len(data) == 7: # Windows Only
+        if len(data) > 7: # Windows Only
             self.checksum  = int(data[5], 16)
             self.timestamp = int(data[6], 16)
         self.path          = str(data[-1])
@@ -424,7 +424,7 @@ class DrcovModule(object):
         self.end           = int(data[3], 16)
         self.entry         = int(data[4], 16)
         self.offset        = int(data[5], 16)
-        if len(data) == 7: # Windows Only
+        if len(data) > 8: # Windows Only
             self.checksum  = int(data[6], 16)
             self.timestamp = int(data[7], 16)
         self.path          = str(data[-1])


### PR DESCRIPTION
These two are definitely wrong, the other one might be too.

Found when some jerk compiled their own linux drcov plugin -- otherwise the precompiled binaries still spit out v2 module tables.

In the v3 case if `len(data) == 7` then `self.timestamp` and `self.path` will be equal
In the v4 case if `len(data) == 7` then `self.timestamp` will throw an exception and `self.path` will be equal to the checksum.

I'm mostly writing it out because I haven't tested these patches because I don't want to compile this...