### PR TITLE
Binary Ninja API fixups

### DIFF
--- a/plugin/lighthouse/util/disassembler/binja_api.py
+++ b/plugin/lighthouse/util/disassembler/binja_api.py
@@ -22,11 +22,10 @@ from binaryninja.plugin import BackgroundTaskThread
 #
 
 binja_user_plugin_path=None
-
+# Compatibility for Binary Ninja Stable & Dev channels (Jan 2019)
 try:
     binja_user_plugin_path=binaryninja.user_plugin_path()
 except TypeError:
-    print("[!] Running with stable API")
     binja_user_plugin_path=binaryninja.user_plugin_path
 
 DEPENDENCY_PATH = os.path.join(
@@ -119,6 +118,7 @@ class BinjaAPI(DisassemblerAPI):
 
     def _init_version(self):
         version_string = None
+        # Compatibility for Binary Ninja Stable & Dev channels (Jan 2019)
         try:
             version_string = binaryninja.core_version()
         except TypeError:
@@ -168,6 +168,7 @@ class BinjaAPI(DisassemblerAPI):
     @property
     def headless(self):
         ret = None
+        # Compatibility for Binary Ninja Stable & Dev channels (Jan 2019)
         try:
             ret = binaryninja.core_ui_enabled()
         except TypeError:

--- a/plugin/lighthouse/util/disassembler/binja_api.py
+++ b/plugin/lighthouse/util/disassembler/binja_api.py
@@ -21,8 +21,16 @@ from binaryninja.plugin import BackgroundTaskThread
 #    ship with PyQt5 bindings in-box.
 #
 
+binja_user_plugin_path=None
+
+try:
+    binja_user_plugin_path=binaryninja.user_plugin_path()
+except TypeError:
+    print("[!] Running with stable API")
+    binja_user_plugin_path=binaryninja.user_plugin_path
+
 DEPENDENCY_PATH = os.path.join(
-    binaryninja.user_plugin_path,
+    binja_user_plugin_path,
     "Lib",
     "site-packages"
 )
@@ -110,7 +118,11 @@ class BinjaAPI(DisassemblerAPI):
         self._python = _binja_get_scripting_instance()
 
     def _init_version(self):
-        version_string = binaryninja.core_version
+        version_string = None
+        try:
+            version_string = binaryninja.core_version()
+        except TypeError:
+            version_string = binaryninja.core_version
 
         # retrieve Binja's version #
         if "-" in version_string: # dev
@@ -155,7 +167,12 @@ class BinjaAPI(DisassemblerAPI):
 
     @property
     def headless(self):
-        return not binaryninja.core_ui_enabled
+        ret = None
+        try:
+            ret = binaryninja.core_ui_enabled()
+        except TypeError:
+            ret = binaryninja.core_ui_enabled
+        return not ret
 
     #--------------------------------------------------------------------------
     # Synchronization Decorators

--- a/plugin/lighthouse/util/disassembler/binja_api.py
+++ b/plugin/lighthouse/util/disassembler/binja_api.py
@@ -22,7 +22,7 @@ from binaryninja.plugin import BackgroundTaskThread
 #
 
 DEPENDENCY_PATH = os.path.join(
-    binaryninja.user_plugin_path(),
+    binaryninja.user_plugin_path,
     "Lib",
     "site-packages"
 )
@@ -110,7 +110,7 @@ class BinjaAPI(DisassemblerAPI):
         self._python = _binja_get_scripting_instance()
 
     def _init_version(self):
-        version_string = binaryninja.core_version()
+        version_string = binaryninja.core_version
 
         # retrieve Binja's version #
         if "-" in version_string: # dev
@@ -155,7 +155,7 @@ class BinjaAPI(DisassemblerAPI):
 
     @property
     def headless(self):
-        return not binaryninja.core_ui_enabled()
+        return not binaryninja.core_ui_enabled
 
     #--------------------------------------------------------------------------
     # Synchronization Decorators


### PR DESCRIPTION
Apparently Binary Ninja made some data accessible via class members instead of getter functions. This PR fixes calls in the disassembler utils.