### PR TITLE
Update ida_api.py

### DIFF
--- a/plugin/lighthouse/util/disassembler/ida_api.py
+++ b/plugin/lighthouse/util/disassembler/ida_api.py
@@ -198,7 +198,7 @@ class IDAAPI(DisassemblerAPI):
         """
         Get the background color of the IDA disassembly view. (IDA 7+)
         """
-        names  = ["Enums", "Structures"]
+        names  = ["Enums", "Structures", "Output window"]
         names += ["Hex View-%u" % i for i in range(5)]
         names += ["IDA View-%c" % chr(ord('A') + i) for i in range(5)]
 
@@ -228,7 +228,7 @@ class IDAAPI(DisassemblerAPI):
         """
         Get the background color of the IDA disassembly view. (IDA 6.x)
         """
-        names  = ["Enums", "Structures"]
+        names  = ["Enums", "Structures", "Output window"]
         names += ["Hex View-%u" % i for i in range(5)]
         names += ["IDA View-%c" % chr(ord('A') + i) for i in range(5)]
 


### PR DESCRIPTION
add "Output window" into names on func"_get_ida_bg_color_ida7(self)" and "_get_ida_bg_color_ida6(self)".

I have worked on something like IDA pro automate.
Last day I just use command like
```
./ida64 -B binary
./ida64 -Sidapython_script_using_lighthouse_plugin.py binary.i64
```
I found out that I get error "Failed to find donor view".
After checking,It is clearly when use "-B" on command line to generate a .idb file, it just have a view "Output window",so I added it into names and everything gone right.

I think this pr is a little useful？😄
