### PR TITLE
Fixes for fixing the PIN build for all operating systems

### DIFF
--- a/coverage/pin/CodeCoverage.cpp
+++ b/coverage/pin/CodeCoverage.cpp
@@ -1,4 +1,3 @@
-using namespace std;
 #include <iostream>
 #include <set>
 #include <string>

--- a/coverage/pin/ImageManager.cpp
+++ b/coverage/pin/ImageManager.cpp
@@ -1,4 +1,3 @@
-using namespace std;
 #include "ImageManager.h"
 #include "pin.H"
 

--- a/coverage/pin/Makefile
+++ b/coverage/pin/Makefile
@@ -1,7 +1,7 @@
 CONFIG_ROOT := $(PIN_ROOT)/source/tools/Config
 include $(CONFIG_ROOT)/makefile.config
 
-TOOL_CXXFLAGS += -std=c++11 -Wno-format -Wno-aligned-new
+TOOL_CXXFLAGS += -std=c++11 -Wno-format
 TOOL_ROOTS := CodeCoverage
 
 $(OBJDIR)CodeCoverage$(PINTOOL_SUFFIX): $(OBJDIR)CodeCoverage$(OBJ_SUFFIX) $(OBJDIR)ImageManager$(OBJ_SUFFIX)

--- a/coverage/pin/build-x64.bat
+++ b/coverage/pin/build-x64.bat
@@ -2,11 +2,12 @@
 cls
 
 cl ^
-    /c ^
+    /c /Fo /nologo /EHa- /EHs- /GR- /GS- /Gd /Gm- /Gy /MD /O2 /Oi- /Oy- /TP /W3 /WX- /Zc:forScope /Zc:inline /Zc:wchar_t /wd4316 /wd4530 /fp:strict ^
+    /DTARGET_IA32E /DHOST_IA32E /DTARGET_WINDOWS /DWIN32 /D__PIN__=1 /DPIN_CRT=1 /D_STLP_IMPORT_IOSTREAMS /D__LP64__ ^
+    /I"%PIN_ROOT%\extras\xed-intel64\include\xed" ^
     /I%PIN_ROOT%\source\include\pin ^
     /I%PIN_ROOT%\source\include\pin\gen ^
     /I%PIN_ROOT%\source\tools\InstLib   ^
-    /I"%PIN_ROOT%\extras\xed-intel64\include\xed" ^
     /I%PIN_ROOT%\extras\components\include ^
     /I%PIN_ROOT%\extras\stlport\include ^
     /I%PIN_ROOT%\extras ^
@@ -16,9 +17,6 @@ cl ^
     /I"%PIN_ROOT%\extras\crt\include\arch-x86_64" ^
     /I%PIN_ROOT%\extras\crt\include\kernel\uapi ^
     /I"%PIN_ROOT%\extras\crt\include\kernel\uapi\asm-x86" ^
-    /nologo /W3 /WX- /O2 ^
-    /D TARGET_IA32E /D HOST_IA32E /D TARGET_WINDOWS /D WIN32 /D __PIN__=1 /D PIN_CRT=1 /D __LP64__ ^
-    /Gm- /MT /GS- /Gy /fp:precise /Zc:wchar_t /Zc:forScope /Zc:inline /GR- /Gd /TP /wd4530 /GR- /GS- /EHs- /EHa- /FP:strict /Oi- ^
     /FIinclude/msvc_compat.h CodeCoverage.cpp ImageManager.cpp ImageManager.h TraceFile.h
 
 link ^
@@ -29,7 +27,7 @@ link ^
     /LIBPATH:%PIN_ROOT%\intel64\lib ^
     /LIBPATH:"%PIN_ROOT%\intel64\lib-ext" ^
     /LIBPATH:"%PIN_ROOT%\extras\xed-intel64\lib" ^
-    /LIBPATH:%PIN_ROOT%\intel64\runtime\pincrt pin.lib xed.lib pinvm.lib kernel32.lib "stlport-static.lib" "m-static.lib" "c-static.lib" "os-apis.lib" "ntdll-64.lib" crtbeginS.obj ^
+    /LIBPATH:%PIN_ROOT%\intel64\runtime\pincrt pin.lib xed.lib pinvm.lib pincrt.lib ntdll-64.lib kernel32.lib crtbeginS.obj ^
     /NODEFAULTLIB ^
     /MANIFEST:NO ^
     /OPT:NOREF ^

--- a/coverage/pin/build-x86.bat
+++ b/coverage/pin/build-x86.bat
@@ -2,8 +2,8 @@
 cls
 
 cl ^
-    /c /EHa- /EHs- /GR- /GS- /Gd /Gm- /Gy /MT /O2 /Oi- /Oy- /TP /W3 /WX- /Zc:forScope /Zc:inline /Zc:wchar_t /fp:precise /nologo /wd4316  ^
-    /DTARGET_IA32 /DHOST_IA32 /DTARGET_WINDOWS /DBIGARRAY_MULTIPLIER=1 /DWIN32 /D__PIN__=1 /DPIN_CRT=1 /D__i386__ ^
+    /c /Fo /nologo /EHa- /EHs- /GR- /GS- /Gd /Gm- /Gy /MD /O2 /Oi- /Oy- /TP /W3 /WX- /Zc:forScope /Zc:inline /Zc:wchar_t /wd4316 /wd4530 /fp:precise ^
+    /DTARGET_IA32 /DHOST_IA32 /DTARGET_WINDOWS /DWIN32 /D__PIN__=1 /DPIN_CRT=1 /D_STLP_IMPORT_IOSTREAMS /D__i386__ ^
     /I"%PIN_ROOT%\extras\xed-ia32\include\xed" ^
     /I%PIN_ROOT%\source\include\pin ^
     /I%PIN_ROOT%\source\include\pin\gen ^
@@ -28,7 +28,7 @@ link ^
     /LIBPATH:%PIN_ROOT%\ia32\lib ^
     /LIBPATH:"%PIN_ROOT%\ia32\lib-ext" ^
     /LIBPATH:"%PIN_ROOT%\extras\xed-ia32\lib" ^
-    /LIBPATH:%PIN_ROOT%\ia32\runtime\pincrt pin.lib xed.lib pinvm.lib kernel32.lib "stlport-static.lib" "m-static.lib" "c-static.lib" "os-apis.lib" "ntdll-32.lib" crtbeginS.obj ^
+    /LIBPATH:%PIN_ROOT%\ia32\runtime\pincrt pin.lib xed.lib pinvm.lib pincrt.lib ntdll-32.lib kernel32.lib crtbeginS.obj ^
     /NODEFAULTLIB ^
     /MANIFEST:NO ^
     /OPT:NOREF ^


### PR DESCRIPTION
This is a collection of changes that should make the PINTool build for; Windows, Linux and MacOS.

I haven't had the chance to test whether it would work under IDA..