### PR TITLE
Lower block trace confidence

### DIFF
--- a/plugins/lighthouse/director.py
+++ b/plugins/lighthouse/director.py
@@ -666,7 +666,7 @@ class CoverageDirector(object):
         #
 
         block_ratio = len(basic_blocks) / float(len(instructions))
-        block_trace_confidence = 0.90
+        block_trace_confidence = 0.80
         logger.debug("Block confidence %f" % block_ratio)
 
         #


### PR DESCRIPTION
Depending on how blocks are traced, on some targets 0.9 is too high. Specifically, some emulator based tracers might consider the first instruction after a return to be a new "block" -- this will inflate the number of instructions with coverage path the threshold, even though the trace should still be considered block cov.