### PR TITLE
Fix unexpected arugment type 'float' (#116)

### DIFF
--- a/plugins/lighthouse/composer/shell.py
+++ b/plugins/lighthouse/composer/shell.py
@@ -1045,7 +1045,7 @@ class ComposingLine(QtWidgets.QPlainTextEdit):
         # set the height of the textbox based on some arbitrary math :D
         LINE_PADDING = self.document().documentMargin()*2
         line_height = self._font_metrics.height() + LINE_PADDING + 2
-        self.setFixedHeight(line_height)
+        self.setFixedHeight(int(line_height))
 
     #--------------------------------------------------------------------------
     # QPlainTextEdit Overloads

--- a/plugins/lighthouse/coverage.py
+++ b/plugins/lighthouse/coverage.py
@@ -6,7 +6,7 @@ import itertools
 import collections
 
 from lighthouse.util import *
-from lighthouse.util.qt import compute_color_on_gradiant
+from lighthouse.util.qt import compute_color_on_gradient
 from lighthouse.metadata import DatabaseMetadata
 
 logger = logging.getLogger("Lighthouse.Coverage")
@@ -311,7 +311,7 @@ class DatabaseCoverage(object):
         Does not require @disassembler.execute_ui decorator as no Qt is touched.
         """
         for function in self.functions.values():
-            function.coverage_color = compute_color_on_gradiant(
+            function.coverage_color = compute_color_on_gradient(
                 function.instruction_percent,
                 self.palette.table_coverage_bad,
                 self.palette.table_coverage_good
@@ -798,7 +798,7 @@ class FunctionCoverage(object):
         self.executions = float(node_sum) / function_metadata.node_count
 
         # bake colors
-        self.coverage_color = compute_color_on_gradiant(
+        self.coverage_color = compute_color_on_gradient(
             self.instruction_percent,
             self.database.palette.table_coverage_bad,
             self.database.palette.table_coverage_good

--- a/plugins/lighthouse/ui/coverage_combobox.py
+++ b/plugins/lighthouse/ui/coverage_combobox.py
@@ -118,7 +118,7 @@ class CoverageComboBox(QtWidgets.QComboBox):
 
         self.setSizeAdjustPolicy(QtWidgets.QComboBox.AdjustToContentsOnFirstShow)
         self.setSizePolicy(QtWidgets.QSizePolicy.Ignored, QtWidgets.QSizePolicy.Ignored)
-        self.setMaximumHeight(self._font_metrics.height()*1.75)
+        self.setMaximumHeight(int(self._font_metrics.height()*1.75))
 
         # draw the QComboBox with a 'Windows'-esque style
         self.setStyle(QtWidgets.QStyleFactory.create("Windows"))
@@ -533,7 +533,7 @@ class CoverageComboBoxModel(QtCore.QAbstractTableModel):
         delete_icon = QtGui.QPixmap(plugin_resource("icons/delete_coverage.png"))
 
         # compute the appropriate size for the deletion icon
-        icon_height = self._font_metrics.height()*0.75
+        icon_height = int(self._font_metrics.height()*0.75)
         icon_width  = icon_height
 
         # scale the icon as appropriate (very likely scaling it down)

--- a/plugins/lighthouse/ui/coverage_overview.py
+++ b/plugins/lighthouse/ui/coverage_overview.py
@@ -194,7 +194,7 @@ class CoverageOverview(object):
 
         # layout the major elements of our widget
         layout = QtWidgets.QGridLayout()
-        layout.setSpacing(get_dpi_scale()*5.0)
+        layout.setSpacing(get_dpi_scale()*5)
         layout.addWidget(self._table_view)
         layout.addWidget(self._toolbar)
 
@@ -214,8 +214,8 @@ class CoverageOverview(object):
             -1*self._settings_menu.sizeHint().height()
         )
         center = QtCore.QPoint(
-            self._settings_button.sizeHint().width()/2,
-            self._settings_button.sizeHint().height()/2
+            int(self._settings_button.sizeHint().width()/2),
+            int(self._settings_button.sizeHint().height()/2)
         )
         where = self._settings_button.mapToGlobal(center+delta)
         self._settings_menu.popup(where)

--- a/plugins/lighthouse/ui/coverage_table.py
+++ b/plugins/lighthouse/ui/coverage_table.py
@@ -145,7 +145,7 @@ class CoverageTableView(QtWidgets.QTableView):
             entry_rect = entry_fm.boundingRect(entry_text)
 
             # select the larger of the two potential column widths
-            column_width = max(title_rect.width(), entry_rect.width()*1.2)
+            column_width = int(max(title_rect.width(), entry_rect.width()*1.2))
 
             # save the final column width
             self.setColumnWidth(i, column_width)
@@ -191,7 +191,7 @@ class CoverageTableView(QtWidgets.QTableView):
         # NOTE: don't ask too many questions about this voodoo math :D
         spacing = entry_fm.height() - entry_fm.xHeight()
         tweak = (17*get_dpi_scale() - spacing)/get_dpi_scale()
-        vh.setDefaultSectionSize(entry_fm.height()+tweak)
+        vh.setDefaultSectionSize(int(entry_fm.height()+tweak))
 
     def _ui_init_table_ctx_menu_actions(self):
         """

--- a/plugins/lighthouse/util/qt/util.py
+++ b/plugins/lighthouse/util/qt/util.py
@@ -71,14 +71,14 @@ def get_dpi_scale():
     # xHeight is expected to be 40.0 at normal DPI
     return int(fm.height() / 173.0)
 
-def compute_color_on_gradiant(percent, color1, color2):
+def compute_color_on_gradient(percent, color1, color2):
     """
     Compute the color specified by a percent between two colors.
     """
     r1, g1, b1, _ = color1.getRgb()
     r2, g2, b2, _ = color2.getRgb()
 
-    # compute the new color across the gradiant of color1 -> color 2
+    # compute the new color across the gradient of color1 -> color 2
     r = r1 + int(percent * (r2 - r1))
     g = g1 + int(percent * (g2 - g1))
     b = b1 + int(percent * (b2 - b1))

--- a/plugins/lighthouse/util/qt/util.py
+++ b/plugins/lighthouse/util/qt/util.py
@@ -69,7 +69,7 @@ def get_dpi_scale():
     fm = QtGui.QFontMetricsF(font)
 
     # xHeight is expected to be 40.0 at normal DPI
-    return fm.height() / 173.0
+    return int(fm.height() / 173.0)
 
 def compute_color_on_gradiant(percent, color1, color2):
     """
@@ -79,9 +79,9 @@ def compute_color_on_gradiant(percent, color1, color2):
     r2, g2, b2, _ = color2.getRgb()
 
     # compute the new color across the gradiant of color1 -> color 2
-    r = r1 + percent * (r2 - r1)
-    g = g1 + percent * (g2 - g1)
-    b = b1 + percent * (b2 - b1)
+    r = r1 + int(percent * (r2 - r1))
+    g = g1 + int(percent * (g2 - g1))
+    b = b1 + int(percent * (b2 - b1))
 
     # return the new color
     return QtGui.QColor(r,g,b)

--- a/plugins/lighthouse/util/qt/waitbox.py
+++ b/plugins/lighthouse/util/qt/waitbox.py
@@ -62,7 +62,7 @@ class WaitBox(QtWidgets.QDialog):
         # configure the main widget / form
         self.setSizeGripEnabled(False)
         self.setModal(True)
-        self._dpi_scale = get_dpi_scale()*5.0
+        self._dpi_scale = get_dpi_scale()*5
 
         # initialize abort button
         self._abort_button = QtWidgets.QPushButton("Cancel")


### PR DESCRIPTION
Hi there,

I've came across the same issue as described in #116, where `float` values are passed when `int`s are expected. I've fixed this for all occurrence I could find. Lighthouse now seems to work fine for me with IDA 7.7 and python 3.10.