### PR TITLE
Fix error in export_to_html function

### DIFF
--- a/plugins/lighthouse/ui/coverage_table.py
+++ b/plugins/lighthouse/ui/coverage_table.py
@@ -665,15 +665,12 @@ class CoverageTableController(object):
         file_dialog.setFileMode(QtWidgets.QFileDialog.AnyFile)
 
         # we construct kwargs here for cleaner PySide/PyQt5 compatibility
-        kwargs = \
-        {
-            "filter": "HTML Files (*.html)",
-            "caption": "Save HTML Report",
-            "directory": suggested_filepath
-        }
+        file_dialog.setNameFilter("HTML Files (*.html)")
+        file_dialog.setWindowTitle("Save HTML Report")
+        file_dialog.setDirectory(suggested_filepath)
 
         # prompt the user with the file dialog, and await their chosen filename(s)
-        filename, _ = file_dialog.getSaveFileName(**kwargs)
+        filename, _ = file_dialog.getSaveFileName()
         if not filename:
             return
 


### PR DESCRIPTION
## Description

When the `Generate HTML report` button is clicked, the following error is displayed:

```
AttributeError: PySide6.QtWidgets.QFileDialog.getSaveFileName(): unsupported keyword 'directory'
```

The `export_to_html` function in the coverage report generator was failing with an AttributeError. However, the behavior in other environments or with IDA is unknown.

This pull request fixes the issue by replacing the `directory` keyword with `setDirectory` method

## Env

- os : macOS Big Sur v11.4
- disassembler: binary ninja(v.3.2.3814 Personal)
- lighthouse: v0.9.2

Thank you.