### PR TITLE
Allow partial module whitelist match within frida-drcov

### DIFF
--- a/coverage/frida/frida-drcov.py
+++ b/coverage/frida/frida-drcov.py
@@ -65,7 +65,7 @@ maps.map(function (e) {
 var filtered_maps = new ModuleMap(function (m) {
     if (whitelist.indexOf('all') >= 0) { return true; }
 
-    return whitelist.indexOf(m.name) >= 0;
+    return whitelist.some(item => m.name.toLowerCase().includes(item.toLowerCase()));
 });
 
 // This function takes a list of GumCompileEvents and converts it into a DRcov


### PR DESCRIPTION
QoL change to allow for partial match and case insensitive on whitelisting modules, 

Before:
`.\frida-drcov.py -w "C:\\Windows\\SYSTEM32\\CRYPTBASE.DLL" 7228`

After
`.\frida-drcov.py -w cryptbase.dll 7228`