### PR TITLE
Functionality to begin thread tracking once a Native or Objective-C method is called

### DIFF
--- a/coverage/frida/frida-drcov.py
+++ b/coverage/frida/frida-drcov.py
@@ -369,12 +369,20 @@ def main():
     parser.add_argument('-D', '--device',
             help='select a device by id [local]',
             default='local')
+    parser.add_argument('-R', '--remote-device',
+            help='select a device by ip:port',
+            default=None)
 
     args = parser.parse_args()
 
     outfile = args.outfile
 
-    device = frida.get_device(args.device)
+    device = 'local'
+    if args.remote_device:
+        print(args.remote_device)
+        device = frida.get_device_manager().add_remote_device(args.remote_device)
+    else:
+        device = frida.get_device(args.device)
 
     target = -1
     for p in device.enumerate_processes():


### PR DESCRIPTION
These changes introduce the ability to only begin stalking threads once a trigger function is called - it stops stalking once the trigger function returns.

With large Application processes on Android and iOS it is not possible to trace everything without the process crashing - this functionality introduces the ability to tightly narrow the scope of tracing so as to avoid crashing the process.

Happy to make any modifications - it's a bit hacky but it does enable iOS/Android coverage generation for targeted methods in large binaries.