### PR TITLE
IDA 9.x SDK fix

### DIFF
--- a/plugins/lighthouse/util/disassembler/ida_api.py
+++ b/plugins/lighthouse/util/disassembler/ida_api.py
@@ -226,7 +226,12 @@ class IDACoreAPI(DisassemblerCoreAPI):
         # attempt to generate an 'html' dump of the first 0x20 bytes (instructions)
         ida_fd = idaapi.fopenWT(path)
         idaapi.gen_file(idaapi.OFILE_LST, ida_fd, imagebase, imagebase+0x20, idaapi.GENFLG_GENHTML)
-        idaapi.eclose(ida_fd)
+        # IDA 9.x SDK fix: removed `idaapi.eclose`, added `ida_fpro.qfclose`
+        if int(idaapi.get_kernel_version()[0]) >= 9:
+            import ida_fpro
+            ida_fpro.qfclose(ida_fd)
+        else:
+            idaapi.eclose(ida_fd)
 
         # read the dumped text
         with open(path, "r") as fd:


### PR DESCRIPTION
Hi,

Just a minor change to make lighthouse work with IDA 9.x SDK API (tested with IDA 9.1).

See also https://github.com/gaasedelen/lighthouse/pull/145 and https://github.com/gaasedelen/lighthouse/issues/146.