### PR TITLE
Fix Coverage Display in Binary Ninja 5.X

### DIFF
--- a/dev_scripts/test_headless.py
+++ b/dev_scripts/test_headless.py
@@ -8,7 +8,7 @@ target = os.path.abspath(os.path.join(
     "boombox.exe"
 ))
 
-print "Opening '%s' headlessly..." % target
+print(f"Opening '{target}' headlessly...") 
 x = binaryninja.BinaryViewType["PE"].open(target)
 x.update_analysis_and_wait()
-print "DONE!"
+print("DONE!")

--- a/plugins/lighthouse/integration/binja_integration.py
+++ b/plugins/lighthouse/integration/binja_integration.py
@@ -1,6 +1,5 @@
 import ctypes
 import logging
-# import binaryninja
 
 from binaryninja import PluginCommand, BinaryView
 from binaryninjaui import UIAction, UIActionHandler, Menu, Sidebar
@@ -92,7 +91,7 @@ class LighthouseBinja(LighthouseCore):
 
         In Binary Ninja, a dctx is a BinaryView (BV).
         """
-        if isinstance(dctx, binaryninja.BinaryView):
+        if isinstance(dctx, BinaryView):
             dctx_id = ctypes.addressof(dctx.handle.contents)
         else:
             dctx_id = str(id(dctx))
@@ -117,6 +116,25 @@ class LighthouseBinja(LighthouseCore):
     # UI Integration (Internal)
     #--------------------------------------------------------------------------
     
+    #
+    # TODO / HACK / XXX / V35 / 2021: Some of Binja's UI elements (such as the
+    # terminal) do not get assigned a BV, even if there is only one open.
+    #
+    # this is problematic, because if the user 'clicks' onto the terminal, and
+    # then tries to execute our UIActions (like 'Load Coverage File'), the
+    # given 'context.binaryView' will be None
+    #
+    # in the meantime, we have to use this workaround that will try to grab
+    # the 'current' bv from the dock. this is not ideal, but it will suffice.
+    #
+    # -----------------
+    #
+    # XXX: It's now 2024, Binja's UI / API stack has grown a lot. it's more
+    # powerful and a bunch of the oddities / hacks lighthouse employed for
+    # binja may no longer apply. this whole file should probably be revisited
+    # and re-factored at some point point.. sorry if it's hard to follow
+    #
+
     # NOTE: The implementations below remain mostly the same, relying on the 
     # original Core/Director logic. The UI stability is now handled by the 
     # SidebarWidget implementation.

--- a/plugins/lighthouse/integration/core.py
+++ b/plugins/lighthouse/integration/core.py
@@ -44,14 +44,9 @@ class LighthouseCore(object):
         self.palette = LighthousePalette()
         self.palette.theme_changed(self.refresh_theme)
 
-        def create_coverage_overview(name, parent, dctx):
-            lctx = self.get_context(dctx, startup=False)
-            widget = disassembler.create_dockable_widget(parent, name)
-            overview = CoverageOverview(lctx, widget)
-            return widget
+        # NOTE: create_coverage_overview removed as it's now handled by the SidebarWidget creation callback
 
-        # the coverage overview widget
-        disassembler.register_dockable("Coverage Overview", create_coverage_overview)
+        # NOTE: disassembler.register_dockable removed here - now handled by Sidebar.addSidebarWidgetType
 
         # install disassembler UI
         self._install_ui()
@@ -190,7 +185,9 @@ class LighthouseCore(object):
         """
         for lctx in self.lighthouse_contexts.values():
             lctx.director.refresh_theme()
-            lctx.coverage_overview.refresh_theme()
+            # Check if overview is initialized before calling refresh_theme
+            if lctx.coverage_overview:
+                lctx.coverage_overview.refresh_theme()
             lctx.painter.force_repaint()
 
     def open_coverage_overview(self, dctx=None):

--- a/plugins/lighthouse/ui/coverage_overview.py
+++ b/plugins/lighthouse/ui/coverage_overview.py
@@ -56,9 +56,10 @@ class CoverageOverview(object):
 
     @property
     def visible(self):
+        # FIX: Replace .visible property access with the Qt standard .isVisible() method
         if not self.widget:
             return False
-        return self.widget.visible
+        return self.widget.isVisible()
 
     def terminate(self):
         """
@@ -288,7 +289,13 @@ class EventProxy(QtCore.QObject):
             if disassembler.NAME == "BINJA":
                 lctx = self._target.lctx
                 core = lctx.core
-                core.binja_close_context(lctx.dctx)
+                # FIX: In SidebarWidget, the 'widget' is the sidebar itself (source), 
+                # which is a SidebarWidget and has its own close/cleanup notifications.
+                # However, the core logic expects the dctx, not widget.
+                # We need to manually determine the dctx from the lctx before passing it.
+                if hasattr(lctx, 'dctx'):
+                    core.binja_close_context(lctx.dctx)
+
 
             # cleanup the UI / qt references for the CoverageOverview elements
             self._target.terminate()
@@ -322,6 +329,7 @@ class EventProxy(QtCore.QObject):
 
         elif int(event.type()) == self.EventUpdateLater:
 
+            # FIX: Use the fixed 'visible' property (which calls isVisible())
             if self._target.visible and self._first_hit:
                 self._first_hit = False
 

--- a/plugins/lighthouse/util/disassembler/binja_api.py
+++ b/plugins/lighthouse/util/disassembler/binja_api.py
@@ -5,7 +5,6 @@ import logging
 import os
 import sys
 import threading
-import binaryninja # Added import
 
 from binaryninja import PythonScriptingInstance, binaryview
 from binaryninja.plugin import BackgroundTaskThread
@@ -195,7 +194,7 @@ class BinjaCoreAPI(DisassemblerCoreAPI):
         current_sidebar = Sidebar.current()
         
         if current_sidebar:
-            # CRITICAL FIX: Use the registered string name "Lighthouse"
+            # FIX: Use the registered plugin name "Lighthouse"
             current_sidebar.focus("Lighthouse")
         else:
             # Fallback for when no sidebar/frame is currently active/focused

--- a/plugins/lighthouse/util/disassembler/binja_api.py
+++ b/plugins/lighthouse/util/disassembler/binja_api.py
@@ -1,13 +1,12 @@
-# -*- coding: utf-8 -*-
+import ctypes
 import collections
 import functools
 import logging
 import os
 import sys
 import threading
-import ctypes # Added import
+import binaryninja # Added import
 
-import binaryninja
 from binaryninja import PythonScriptingInstance, binaryview
 from binaryninja.plugin import BackgroundTaskThread
 from binaryninjaui import (Sidebar, SidebarContextSensitivity, SidebarWidget,
@@ -29,6 +28,8 @@ logger = logging.getLogger("Lighthouse.API.Binja")
 
 
 def execute_sync(function):
+    # 
+
     """
     Synchronize with the disassembler for safe database access.
     """
@@ -418,6 +419,11 @@ class LighthouseWidget(SidebarWidget):
         CoverageOverview(lctx, self)
         
         # The parent constructor already handles UIActionHandler setup, so we skip it here.
+        
+    @property
+    def visible(self):
+        # FIX: Implement the .visible property expected by CoverageOverview.py's EventProxy
+        return self.isVisible()
 
 
 class LighthouseWidgetType(SidebarWidgetType):

--- a/plugins/lighthouse/util/disassembler/binja_api.py
+++ b/plugins/lighthouse/util/disassembler/binja_api.py
@@ -13,6 +13,10 @@ from ..misc import is_mainthread, not_mainthread
 import binaryninja
 from binaryninja import PythonScriptingInstance, binaryview
 from binaryninja.plugin import BackgroundTaskThread
+from binaryninjaui import Sidebar, SidebarWidget, SidebarWidgetType, SidebarContextSensitivity, SidebarWidgetLocation, UIActionHandler, UIContext
+from PySide6 import QtCore
+from PySide6.QtCore import Qt, QRectF
+from PySide6.QtGui import QImage, QPixmap, QPainter, QFont, QColor
 
 logger = logging.getLogger("Lighthouse.API.Binja")
 
@@ -160,29 +164,41 @@ class BinjaCoreAPI(DisassemblerCoreAPI):
     #--------------------------------------------------------------------------
 
     def register_dockable(self, dockable_name, create_widget_callback):
-        dock_handler = DockHandler.getActiveDockHandler()
-        dock_handler.addDockWidget(dockable_name, create_widget_callback, QtCore.Qt.RightDockWidgetArea, QtCore.Qt.Horizontal, False)
+        Sidebar.addSidebarWidgetType(LighthouseWidgetType())
 
     def create_dockable_widget(self, parent, dockable_name):
-        return DockableWidget(parent, dockable_name)
+        # return DockableWidget(parent, dockable_name)
+        pass
 
     def show_dockable(self, dockable_name):
-        dock_handler = DockHandler.getActiveDockHandler()
-        dock_handler.setVisible(dockable_name, True)
+        """
+        Show the named dockable widget.
+        """
+        # --- FIX: Check if Sidebar.current() returns a valid object ---
+        current_sidebar = Sidebar.current()
+        
+        if current_sidebar:
+            # CRITICAL FIX: Use the registered string name "Lighthouse"
+            current_sidebar.focus("Lighthouse") 
+        else:
+            # Use self.warning (inherited from DisassemblerCoreAPI) to notify the user
+            self.warning("Failed to show dockable '%s': No active BinaryView window with a sidebar found." % dockable_name)
 
     def hide_dockable(self, dockable_name):
-        dock_handler = DockHandler.getActiveDockHandler()
-        dock_handler.setVisible(dockable_name, False)
+        # dock_handler = DockHandler.getActiveDockHandler()
+        # dock_handler.setVisible(dockable_name, False)
+        pass
 
     #--------------------------------------------------------------------------
     # XXX Binja Specfic Helpers
     #--------------------------------------------------------------------------
 
     def binja_get_bv_from_dock(self):
-        dh = DockHandler.getActiveDockHandler()
-        if not dh:
+        ac = UIContext.activeContext()
+        
+        if not ac:
             return None
-        vf = dh.getViewFrame()
+        vf = ac.getCurrentViewFrame()
         if not vf:
             return None
         vi = vf.getCurrentViewInterface()
@@ -208,23 +224,16 @@ class BinjaContextAPI(DisassemblerContextAPI):
     #--------------------------------------------------------------------------
 
     def get_current_address(self):
-
-        # TODO/V35: this doen't work because of the loss of context bug...
-        #ctx = UIContext.activeContext()
-        #ah = ctx.contentActionHandler()
-        #ac = ah.actionContext()
-        #return ac.address
-
-        dh = DockHandler.getActiveDockHandler()
-        if not dh:
-            return 0
-        vf = dh.getViewFrame()
-        if not vf:
-            return 0
-        ac = vf.actionContext()
+        ac = UIContext.activeContext()
         if not ac:
             return 0
-        return ac.address
+        vf = ac.getCurrentViewFrame()
+        if not vf:
+            return 0
+        actx = vf.actionContext()
+        if not actx:
+            return 0
+        return actx.address
 
     @BinjaCoreAPI.execute_read
     def get_database_directory(self):
@@ -283,8 +292,8 @@ class BinjaContextAPI(DisassemblerContextAPI):
         else:
             return False
 
-        dh = DockHandler.getActiveDockHandler()
-        vf = dh.getViewFrame()
+        ac = UIContext.activeContext()
+        vf = ac.getCurrentViewFrame()
         vi = vf.getCurrentViewInterface()
 
         return vi.navigateToFunction(func, address)
@@ -363,61 +372,31 @@ class RenameHooks(binaryview.BinaryDataNotification):
 # UI
 #------------------------------------------------------------------------------
 
-if QT_AVAILABLE:
+class LighthouseWidget(SidebarWidget):
+    def __init__(self, name, frame, data):
+        SidebarWidget.__init__(self, name)
+        self.actionHandler = UIActionHandler()
+        self.actionHandler.setupActionHandler(self)
 
-    import binaryninjaui
-    from binaryninjaui import DockHandler, DockContextHandler, UIContext, UIActionHandler
+class LighthouseWidgetType(SidebarWidgetType):
+    def __init__(self):
+        icon = QImage(56, 56, QImage.Format_RGB32)
+        icon.fill(0)
 
-    class DockableWidget(QtWidgets.QWidget, DockContextHandler):
-        """
-        A dockable Qt widget for Binary Ninja.
-        """
+        p = QPainter()
+        p.begin(icon)
+        p.setFont(QFont("Open Sans", 56))
+        p.setPen(QColor(255, 255, 255, 255))
+        p.drawText(QRectF(0, 0, 56, 56), Qt.AlignCenter, "L")
+        p.end()
 
-        def __init__(self, parent, name):
-            QtWidgets.QWidget.__init__(self, parent)
-            DockContextHandler.__init__(self, self, name)
+        SidebarWidgetType.__init__(self, icon, "Lighthouse")
 
-            self.actionHandler = UIActionHandler()
-            self.actionHandler.setupActionHandler(self)
+    def createWidget(self, frame, data):
+        return LighthouseWidget("Lighthouse", frame, data)
 
-            self._active_view = None
-            self._visible_for_view = collections.defaultdict(lambda: False)
+    def defaultLocation(self):
+        return SidebarWidgetLocation.RightContent
 
-        @property
-        def visible(self):
-            return self._visible_for_view[self._active_view]
-
-        @visible.setter
-        def visible(self, is_visible):
-            self._visible_for_view[self._active_view] = is_visible
-
-        def shouldBeVisible(self, view_frame):
-            if not view_frame:
-                return False
-
-            if USING_PYSIDE6:
-                import shiboken6 as shiboken
-            else:
-                import shiboken2 as shiboken
-
-            vf_ptr = shiboken.getCppPointer(view_frame)[0]
-            return self._visible_for_view[vf_ptr]
-
-        def notifyVisibilityChanged(self, is_visible):
-            self.visible = is_visible
-
-        def notifyViewChanged(self, view_frame):
-            if not view_frame:
-                self._active_view = None
-                return
-
-            if USING_PYSIDE6:
-                import shiboken6 as shiboken
-            else:
-                import shiboken2 as shiboken
-
-            self._active_view = shiboken.getCppPointer(view_frame)[0]
-
-            if self.visible:
-                dock_handler = DockHandler.getActiveDockHandler()
-                dock_handler.setVisible(self.m_name, True)
+    def contextSensitivity(self):
+        return SidebarContextSensitivity.SelfManagedSidebarContext


### PR DESCRIPTION
I took a crack at getting Lighthouse to work in the newest stable release of binary ninja. I worked on top of the fix made by #148, however I noticed that the code didn't properly display a coverage file, so I went through and updated the binja API. Although I might have messed up the Ida display by messing with the core api. Migrated from DockableWidget to a more supported SidebarWidget, which also helps with some of the annoying issues. I did still have to do some hacky life cycle management.